### PR TITLE
Add support to multiple conditions of the same type and methods with variable parameters number

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $food = $this->foodPantry->get($record);
 
 | Argument    	 | Value 																	 			 |
 | -------------- | ------------------------------------------------------------------------------------- |
-| $record  	 	 | It accepts modal ID ( `Illuminate\Database\Eloquent\Model`, `string`, `id` )			 |
+| $record  	 	 | It accepts model ID ( `Illuminate\Database\Eloquent\Model`, `string`, `id` )			 |
 | $relationships | It's Optional, You can pass relationship arguments in array. see <a href="#fetch-data-with-relationships">relationships</a> examples  			 |
 
 > It will also works with Route Model Binding.
@@ -121,7 +121,8 @@ With conditions, it's an optional parameter.
 
 $foods = $this->foodPantry->getAll(
 	conditions: [
-		'where' => [ 'status', true ],
+		['where', 'status', true ],
+		['whereHas', 'relationshipName' ],
 	]
 );
 ```
@@ -228,7 +229,6 @@ $food = $this->foodPantry->destroy($key);
 | Argument   	 | Value 														   				 |
 | -------------- | ----------------------------------------------------------------------------- |
 | $key  	 	 | It accepts record ID ( `Illuminate\Database\Eloquent\Model`, `string`, `id` ) |
-| $data  	 	 | Array key-value pair 										   				 |
 
 As a return true on record deleted, false on failure.
 

--- a/src/Pantries/Concerns/InteractsWithRecord.php
+++ b/src/Pantries/Concerns/InteractsWithRecord.php
@@ -47,16 +47,10 @@ trait InteractsWithRecord
 
     protected function resolveWhereCondition(Builder $query, array $conditions): Builder
     {
-        if ( $conditions ) {
-            foreach ( $conditions as $functionName => $condition ) {
-
-                if ( count($condition) == 3 ) {
-                    [$column, $operator, $value] = $condition;
-                    $query->{$functionName}($column, $operator, $value);
-                } else {
-                    [$column, $value] = $condition;
-                    $query->{$functionName}($column, $value);
-                }
+        if ($conditions) {
+            foreach ($conditions as $condition) {
+                $functionName = array_shift($condition);
+                $query->{$functionName}(...$condition);
             }
         }
         return $query;


### PR DESCRIPTION
Refactor resolveWhereCondition method to support multiple conditions of the same type

Before this change, the resolveWhereCondition method only supported one condition per type (e.g. one where condition). This was limiting for users who needed to apply multiple conditions of the same type to a query.

With this change, the resolveWhereCondition method now accepts an array of arrays, where the first element of each subarray is the name of the function to call (e.g. "where"), and the remaining elements are the arguments to pass to the function. This makes it possible to apply multiple conditions of the same type to a query, as well as to use any function that takes a variable number of arguments, such as the "whereHas" method that only takes one parameter.

Example usage:
```php
$foods = $this->foodPantry->getAll(
	conditions: [
		['where', 'status', true ],
		['where', 'type_id', 3 ],
		['whereHas', 'relationshipName' ],
	]
);
```

This commit also simplifies the code by removing unnecessary conditional statements and using the spread operator for function arguments.

Thanks for considering this contribution! Let me know if you have any questions or feedback.

Best regards,
Luis Acosta
