### PR TITLE
Fix get method to retrieve requested relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ $food = $this->foodPantry->get($record);
 | Argument    	 | Value 																	 			 |
 | -------------- | ------------------------------------------------------------------------------------- |
 | $record  	 	 | It accepts model ID ( `Illuminate\Database\Eloquent\Model`, `string`, `id` )			 |
+| $columns  	 | Column names in array format, by default it will be `['*']` 				  			   |
 | $relationships | It's Optional, You can pass relationship arguments in array. see <a href="#fetch-data-with-relationships">relationships</a> examples  			 |
 
 > It will also works with Route Model Binding.

--- a/src/Pantries/Pantry.php
+++ b/src/Pantries/Pantry.php
@@ -54,14 +54,15 @@ abstract class Pantry implements Contracts\Pantry
 
     	$query = static::getEloquentQuery()->select($columns);
     	if ( is_array($record) ) {
-    		$record = $query->where($record)->first();
+    		$query->where($record);
     	} else {
     		$routeKeyName = app(static::getModel())->getRouteKeyName();
 
-    		$record = $query->where($routeKeyName, $record)->first();
+    		$query->where($routeKeyName, $record);
     	}
+		$this->resolveRelationship($query, $relationships);
 
-        return $record;
+        return $query->first();
     }
 
     /**


### PR DESCRIPTION
Resolve issue #6  : `get` method not retrieving requested relationships. 

Updated the `get` method to include the requested relationships in the query by calling the existing `resolveRelationship` method. 

Tested the changes and verified that the relations property is no longer empty.

Thank you!